### PR TITLE
Fix PyYAML 'AttributeError: cython_sources'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyYAML==6.0
+PyYAML==6.0.1


### PR DESCRIPTION
Fix cytomine/Cytomine-installer#2 by setting version of PyYAML to 6.0.1